### PR TITLE
Remove deprecated method

### DIFF
--- a/Swifternalization/Regex.swift
+++ b/Swifternalization/Regex.swift
@@ -96,6 +96,6 @@ final class Regex {
         let startRange = str.startIndex.advancedBy(range.location)
         let endRange = startRange.advancedBy(range.length)
         
-        return str.substringWithRange(Range(start: startRange, end: endRange))
+        return str.substringWithRange(Range(startRange..<endRange))
     }
 }

--- a/Swifternalization/Regex.swift
+++ b/Swifternalization/Regex.swift
@@ -96,6 +96,6 @@ final class Regex {
         let startRange = str.startIndex.advancedBy(range.location)
         let endRange = startRange.advancedBy(range.length)
         
-        return str.substringWithRange(Range(startRange..<endRange))
+        return str.substringWithRange(startRange..<endRange)
     }
 }


### PR DESCRIPTION
Remove deprecated method in Swift 2.2 (definitively removed with Swift 3.0)